### PR TITLE
feat: Add Simpson's diversity indices

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,7 @@
     <script src="script.js"> </script>
 
     <h2>Instrução de uso:</h2>
-    <p><strong>DIV WEB:</strong> aplicativo web desenvolvido em Javascript para determinação do <strong>Índice de Diversidade de Shannon (H')</strong> e a
-        <strong> Equabilidade de Pielou (J) </strong>.</p>
+    <p><strong>DIV WEB:</strong> aplicativo web desenvolvido em Javascript para determinação do <strong>Índice de Diversidade de Shannon (H')</strong>, da <strong>Equabilidade de Pielou (J)</strong>, do <strong>Índice de Simpson (D)</strong>, do <strong>Índice de Diversidade de Simpson (1-D)</strong> e do <strong>Índice de Simpson Inverso (1/D)</strong>.</p>
     <p>O arquivo de entrada deve ser no formato csv, com duas colunas. Uma coluna deve conter as espécies e a outras,
         necessariamente nomeada como <strong>n</strong>, deve conter o número de indivíduos de cada espécie.</p>
     <p>Arquivo exemplo disponível <a href="https://drive.google.com/open?id=16Au4HoNPAKyHIxp0Jl2qpBQrdCagVEas"

--- a/script.js
+++ b/script.js
@@ -68,6 +68,26 @@ let btn_upload = document.getElementById("btn-upload-csv").addEventListener("cli
             let PropSpp = comunidade.map(pi);
             console.log(PropSpp);
 
+            // Simpson's D calculation
+            // Calculate pi^2
+            let pi_squared = PropSpp.map(p => p * p);
+
+            // Calculate Simpson's D
+            let sum_pi_squared = pi_squared.reduce((sum, val) => sum + val, 0);
+            let simpsonD = parseFloat(sum_pi_squared).toFixed(2);
+
+            // Calculate Simpson's Index of Diversity (1-D)
+            let simpson_1_minus_D_raw = 1 - sum_pi_squared;
+            let formatted_simpson_1_minus_D = parseFloat(simpson_1_minus_D_raw).toFixed(2);
+
+            // Calculate Inverse Simpson Index (1/D)
+            let formatted_inverse_simpson_D;
+            if (sum_pi_squared === 0) {
+                formatted_inverse_simpson_D = "N/A";
+            } else {
+                let inverse_simpson_D_raw = 1 / sum_pi_squared;
+                formatted_inverse_simpson_D = parseFloat(inverse_simpson_D_raw).toFixed(2);
+            }
 
             // log de pi
 
@@ -106,6 +126,9 @@ let btn_upload = document.getElementById("btn-upload-csv").addEventListener("cli
             resultado.innerHTML += `<p> Total de espécies: ${spp} spp; </p>`
             resultado.innerHTML += `<p> Índice de Shannon: ${H} nat.ind; </p>`
             resultado.innerHTML += `<p> Equabilidade de Pielou: ${J}. </p>`
+            resultado.innerHTML += `<p> Índice de Simpson (D): ${simpsonD}</p>`;
+            resultado.innerHTML += `<p> Índice de Diversidade de Simpson (1-D): ${formatted_simpson_1_minus_D}</p>`;
+            resultado.innerHTML += `<p> Índice de Simpson Inverso (1/D): ${formatted_inverse_simpson_D}</p>`;
 
         }
     });


### PR DESCRIPTION
Extended the application to calculate and display three variations of Simpson's diversity index:
- Simpson's Index (D): Sum of squared proportions (pi^2).
- Simpson's Index of Diversity (1-D).
- Inverse Simpson Index (1/D), with a check for division by zero.

The `script.js` file was updated with the calculation logic for these indices, and they are now displayed in the results area. The `index.html` file was updated to include these new indices in the application's description.

All calculations are formatted to two decimal places.