### PR TITLE
Fix contact paragraph closure

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <p>O arquivo de entrada deve ser no formato csv, com duas colunas. Uma coluna deve conter as espécies e a outras,
         necessariamente nomeada como <strong>n</strong>, deve conter o número de indivíduos de cada espécie.</p>
     <p>Arquivo exemplo disponível <a href="https://drive.google.com/open?id=16Au4HoNPAKyHIxp0Jl2qpBQrdCagVEas"
-            target="_blank">aqui.</a>
+            target="_blank">aqui.</a></p>
     <h2>Contato:</h2>
     Desenvolvido por <a href="mailto:higuchip@gmail.com">Pedro Higuchi</a>.<br> 
 


### PR DESCRIPTION
## Summary
- close the instructions paragraph before the contact section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f60138588324bead32b79a7a50a7