### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Shannon diversity index (H') and Pielou Evenness index (J) using Javascript.
 
-Aplicativo Web em Javascript  om o propósito de determinação do Índice de Diversidade Shannon (H') e a Equabilidade de Pielou (J)..
+Aplicativo Web em Javascript com o propósito de determinação do Índice de Diversidade Shannon (H') e a Equabilidade de Pielou (J).


### PR DESCRIPTION
## Summary
- fix the Portuguese phrase in README to use "Javascript **com**" instead of "Javascript om" and drop the extra period

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f6338174832488f6888a7bab4c15